### PR TITLE
Add interactive aurora to requests page

### DIFF
--- a/readingList.md
+++ b/readingList.md
@@ -9,6 +9,16 @@ A running catalog of books and series that continue to shape how I think.
 ## Science Fiction
 - Isaac Asimov
   - Foundation series
+    - Prelude to Foundation — Hari Seldon's origins amid Imperial intrigue
+    - Forward the Foundation — Seldon's struggle to complete psychohistory
+    - Foundation — the birth of the Foundation and first Seldon Crises
+    - Foundation and Empire — the Mule's disruption of the plan
+    - Second Foundation — the hunt for the secretive Second Foundation
+    - Foundation's Edge — a search for the mythical planet Earth
+    - Foundation and Earth — the quest to find Earth's legacy
+    - Foundation's Fear — revival of galactic politics and simulation ethics
+    - Foundation and Chaos — confrontation with robot-driven conspiracies
+    - Foundation's Triumph — the reconciliation of human and robotic destinies
   - The Naked Sun
   - The Robots of Dawn
 - Philip K. Dick
@@ -16,25 +26,25 @@ A running catalog of books and series that continue to shape how I think.
   - Minority Report
 - Ray Nayler — *The Mountain in the Sea*
 - Jack Vance
-  - The Languages of Pao
-  - Tales of the Dying Earth
-- Exurbia — *The Fifth Science*
+  - [The Languages of Pao](https://en.wikipedia.org/wiki/The_Languages_of_Pao) ([Amazon](https://amzn.to/3Mo0uRx))
+  - [Tales of the Dying Earth](https://en.wikipedia.org/wiki/Tales_of_the_Dying_Earth) ([Amazon](https://amzn.to/3MlNg7L))
+- Exurbia — *[The Fifth Science](https://en.wikipedia.org/wiki/The_Fifth_Science)* ([Amazon](https://amzn.to/4pYEFXi))
 - QNTM
   - There Is No Antimemetics Division
   - Valuable Humans in Transit
   - Ra
 - Greg Egan — *Morphotrophic*
 - Philip José Farmer — *The Unreasoning Mask*
-- Joi Ito & Jeff Howe — *Whiplash: How to Survive Our Faster Future*
+- Joi Ito & Jeff Howe — *[Whiplash: How to Survive Our Faster Future](https://en.wikipedia.org/wiki/Whiplash_(book))* ([Amazon](https://amzn.to/4azgb23))
 - Olaf Stapledon
   - Last and First Men
   - Star Maker
 
 ## Technical
-- Rob J Hyndman — *Forecasting: Principles and Practice*
+- Rob J Hyndman — *[Forecasting: Principles and Practice](https://en.wikipedia.org/wiki/Forecasting:_Principles_and_Practice)* ([Amazon](https://amzn.to/3XC3Hzj))
 - Peter Thiel — *Zero to One*
-- James C. Scott — *Seeing Like a State*
-- Stephen King — *On Writing*
+- James C. Scott — *[Seeing Like a State](https://en.wikipedia.org/wiki/Seeing_Like_a_State)* ([Amazon](https://amzn.to/3MjVIEF))
+- Stephen King — *[On Writing](https://en.wikipedia.org/wiki/On_Writing)* ([Amazon](https://amzn.to/4pYpxZW))
 - Most Stripe Press books on technical leadership
 - Most O'Reilly books on AI, machine learning, and software development
 
@@ -42,4 +52,19 @@ A running catalog of books and series that continue to shape how I think.
 - Mitchell Waldrop — *The Dream Machine*
 
 ## Fantasy
-- Most Raymond E. Feist books
+- Raymond E. Feist — Riftwar Cycle
+  - Magician — Pug and Tomas discover their destinies during the Riftwar
+  - Silverthorn — a desperate quest to save Anita from a poisoned blade
+  - A Darkness at Sethanon — a climactic battle to protect Midkemia
+  - Prince of the Blood — twin princes unravel conspiracies in Kesh
+  - The King's Buccaneer — a kidnapping sparks a globe-spanning rescue
+  - Shadow of a Dark Queen — mercenaries confront ancient evil in Novindus
+  - Rise of a Merchant Prince — Roo Avery builds an empire amid war
+  - Rage of a Demon King — the dark queen's forces threaten Midkemia
+  - Shards of a Broken Crown — rebuilding lands ravaged by war
+  - Krondor: The Betrayal — game-inspired intrigue and invasion
+  - Krondor: The Assassins — assassins and guilds unsettle the Kingdom
+  - Krondor: Tear of the Gods — a lost artifact jeopardizes Midkemia's faiths
+  - Talon of the Silver Hawk — a lone survivor vows revenge and renewal
+  - King of Foxes — Talon navigates political traps to protect the Orosini
+  - Exile's Return — alliances shift as ancient threats reemerge

--- a/requests.md
+++ b/requests.md
@@ -6,5 +6,189 @@ permalink: /requests/
 
 Have a request? Email it to me at [jameson.lee@emergence.studio](mailto:jameson.lee@emergence.studio)!
 
-Outstanding Requests:
- - _your suggestion here?_
+<div class="request-aurora-card">
+  <canvas id="request-aurora" aria-hidden="true"></canvas>
+  <div class="request-aurora-copy">
+    <h2>Send your spark</h2>
+    <p>Move your cursor (or tap) to stir glowing ribbons that fade into the ether while you dream up the next request.</p>
+  </div>
+</div>
+
+<style>
+  .request-aurora-card {
+    position: relative;
+    margin: 2rem 0;
+    min-height: 320px;
+    border-radius: 18px;
+    overflow: hidden;
+    background: radial-gradient(circle at 20% 20%, rgba(111, 196, 255, 0.25), transparent 35%),
+                radial-gradient(circle at 80% 0%, rgba(255, 144, 214, 0.25), transparent 30%),
+                #0b1026;
+    color: #e8f1ff;
+    box-shadow: 0 14px 45px rgba(11, 16, 38, 0.35);
+  }
+
+  #request-aurora {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+  }
+
+  .request-aurora-copy {
+    position: relative;
+    z-index: 1;
+    padding: 2.5rem;
+    max-width: 520px;
+    text-shadow: 0 1px 12px rgba(11, 16, 38, 0.45);
+  }
+
+  .request-aurora-copy h2 {
+    margin-top: 0;
+    font-size: 1.9rem;
+    letter-spacing: 0.02em;
+  }
+
+  .request-aurora-copy p {
+    margin-bottom: 0;
+    line-height: 1.7;
+    font-size: 1.03rem;
+  }
+
+  @media (max-width: 640px) {
+    .request-aurora-card {
+      min-height: 260px;
+    }
+
+    .request-aurora-copy {
+      padding: 1.8rem;
+    }
+
+    .request-aurora-copy h2 {
+      font-size: 1.5rem;
+    }
+  }
+</style>
+
+<script>
+  (() => {
+    const canvas = document.getElementById('request-aurora');
+    if (!canvas || !canvas.getContext) return;
+
+    const ctx = canvas.getContext('2d');
+    const palette = [
+      '#6fc4ff',
+      '#ff90d6',
+      '#a0ffcb',
+      '#7c6dff',
+      '#f6ff8f'
+    ];
+
+    const particles = [];
+    let width = 0;
+    let height = 0;
+    let deviceScale = Math.min(window.devicePixelRatio || 1, 2);
+
+    const pointer = { x: 0, y: 0, active: false };
+
+    class Particle {
+      constructor(x, y) {
+        this.x = x;
+        this.y = y;
+        this.life = Math.random() * 60 + 60;
+        this.size = Math.random() * 2.4 + 1.1;
+        const angle = Math.random() * Math.PI * 2;
+        const speed = Math.random() * 0.7 + 0.4;
+        this.vx = Math.cos(angle) * speed;
+        this.vy = Math.sin(angle) * speed;
+        this.hue = palette[Math.floor(Math.random() * palette.length)];
+        this.swing = Math.random() * 0.18 + 0.02;
+        this.theta = Math.random() * Math.PI * 2;
+      }
+
+      update() {
+        this.life -= 1;
+        this.theta += this.swing;
+        this.x += this.vx + Math.cos(this.theta) * 0.45;
+        this.y += this.vy + Math.sin(this.theta) * 0.4;
+        this.size *= 0.995;
+      }
+
+      draw() {
+        const alpha = Math.max(this.life / 120, 0);
+        ctx.beginPath();
+        const gradient = ctx.createRadialGradient(this.x, this.y, 0, this.x, this.y, this.size * 14);
+        gradient.addColorStop(0, `${this.hue}aa`);
+        gradient.addColorStop(1, `${this.hue}00`);
+        ctx.fillStyle = gradient;
+        ctx.arc(this.x, this.y, this.size * 12, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.beginPath();
+        ctx.fillStyle = `${this.hue}${Math.floor(alpha * 200 + 40).toString(16).padStart(2, '0')}`;
+        ctx.arc(this.x, this.y, this.size * 3.3, 0, Math.PI * 2);
+        ctx.fill();
+      }
+    }
+
+    function resize() {
+      const rect = canvas.getBoundingClientRect();
+      deviceScale = Math.min(window.devicePixelRatio || 1, 2);
+      width = rect.width;
+      height = rect.height;
+      canvas.width = width * deviceScale;
+      canvas.height = height * deviceScale;
+      ctx.resetTransform();
+      ctx.scale(deviceScale, deviceScale);
+    }
+
+    function spawn(count = 10, origin) {
+      const rect = canvas.getBoundingClientRect();
+      const baseX = origin ? origin.x : rect.width / 2 + Math.random() * rect.width * 0.2 - rect.width * 0.1;
+      const baseY = origin ? origin.y : rect.height / 2 + Math.random() * rect.height * 0.2 - rect.height * 0.1;
+      for (let i = 0; i < count; i += 1) {
+        particles.push(new Particle(baseX, baseY));
+      }
+    }
+
+    function tick() {
+      ctx.fillStyle = 'rgba(9, 12, 28, 0.2)';
+      ctx.fillRect(0, 0, width, height);
+
+      for (let i = particles.length - 1; i >= 0; i -= 1) {
+        const p = particles[i];
+        p.update();
+        p.draw();
+        if (p.life <= 0 || p.size < 0.2 || p.x < -40 || p.x > width + 40 || p.y < -40 || p.y > height + 40) {
+          particles.splice(i, 1);
+        }
+      }
+
+      requestAnimationFrame(tick);
+    }
+
+    canvas.addEventListener('pointermove', (event) => {
+      const rect = canvas.getBoundingClientRect();
+      pointer.x = event.clientX - rect.left;
+      pointer.y = event.clientY - rect.top;
+      pointer.active = true;
+      spawn(6, pointer);
+    });
+
+    canvas.addEventListener('pointerleave', () => {
+      pointer.active = false;
+    });
+
+    canvas.addEventListener('pointerdown', (event) => {
+      const rect = canvas.getBoundingClientRect();
+      pointer.x = event.clientX - rect.left;
+      pointer.y = event.clientY - rect.top;
+      spawn(16, pointer);
+    });
+
+    window.addEventListener('resize', resize);
+
+    resize();
+    spawn(80);
+    tick();
+  })();
+</script>


### PR DESCRIPTION
## Summary
- remove the outdated outstanding requests placeholder from the requests page
- add an aurora-inspired interactive canvas that responds to cursor movement and taps
- include responsive styling to frame the new interaction

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693616a0f850832e87e59fde546c8e6e)